### PR TITLE
インデントの字下げを4文字にする

### DIFF
--- a/pizero-book/publication.json
+++ b/pizero-book/publication.json
@@ -8,7 +8,7 @@
   "name": "CHIRIMEN Raspberry Pi Zero W チュートリアル",
   "author": "CHIRIMEN Open Hardware Community <chirimen.open.hardware@gmail.com>",
   "inLanguage": "ja",
-  "dateModified": "2023-10-01T08:46:24.060Z",
+  "dateModified": "2023-10-05T02:26:04.755Z",
   "readingOrder": [
     {
       "url": "docs/index.html",

--- a/pizero-book/themes/packages/@vivliostyle/theme-base/css/common/meta-properties.css
+++ b/pizero-book/themes/packages/@vivliostyle/theme-base/css/common/meta-properties.css
@@ -51,7 +51,7 @@
    * Spacing
    */
   --vs-spacing-rlh: calc(var(--vs-line-height) * 1rem);
-  --vs-spacing-inline-indent: min(2ch, 5vw);
+  --vs-spacing-inline-indent: min(4ch, 5vw);
 
   /**
    * Borders


### PR DESCRIPTION
closed #3 

2文字のときは、間に図が入ると復帰したときのインデントがわかりずらかったけど

<img width="404" alt="スクリーンショット 2023-10-05 11 21 05" src="https://github.com/gurezo/chirimen.org/assets/132000/5a7b87ed-c45a-4815-bc3c-052e4500971e">

4文字にすると、図の後のインデントがどこから始まっているのかわかりやすい

<img width="435" alt="スクリーンショット 2023-10-05 11 27 12" src="https://github.com/gurezo/chirimen.org/assets/132000/a62d11cb-5f26-4eb9-9010-08f8e94acd2d">


