### PR TITLE
箇条書きの中にあり、図表番号のない画像の余白を図表番号ありと同じように設定した

### DIFF
--- a/pizero-book/themes/packages/@vivliostyle/theme-base/css/common/basic.css
+++ b/pizero-book/themes/packages/@vivliostyle/theme-base/css/common/basic.css
@@ -596,6 +596,11 @@ figcaption {
   text-indent: var(--vs--figcaption-text-indent);
 }
 
+ul > li > img {
+  margin-block: var(--vs--figure-margin-block);
+  margin-inline: var(--vs--figure-margin-inline);
+}
+
 ul,
 ol,
 dl {


### PR DESCRIPTION
close #4 

箇条書きの中にない場合や、箇条書きの中にあっても図表番号が設定されている場合の画像は上下に余白がある

<img width="436" alt="スクリーンショット 2023-10-05 11 47 15" src="https://github.com/gurezo/chirimen.org/assets/132000/d02b9190-6524-4d1c-9ec9-24db72862d94">

ただし箇条書きの中にあって図表番号がない場合は、余白がなく読みづらい

<img width="406" alt="スクリーンショット 2023-10-05 11 47 35" src="https://github.com/gurezo/chirimen.org/assets/132000/7b81bf96-7163-4960-ae51-95f028b3e593">

この修正では、箇条書きの中にあり、図表番号のない画像の余白を図表番号ありと同じように設定した


<img width="382" alt="スクリーンショット 2023-10-05 12 38 38" src="https://github.com/gurezo/chirimen.org/assets/132000/7d92465d-186e-44e2-a174-3f53d3aa8c30">


