### PR TITLE
外部リンクだけの箇条書きを、本文中出現箇所でリンクに変更する

### DIFF
--- a/pizero-book/docs/chirimenGeneric.html
+++ b/pizero-book/docs/chirimenGeneric.html
@@ -45,15 +45,11 @@
       </section>
       <section class="level2" aria-labelledby="そもそもl-チカって何">
         <h2 id="そもそもl-チカって何">そもそも「L チカ」って何？</h2>
-        <p>「L チカ」とは、LED を点けたり消したりチカチカ点滅させることです。今回は「LED を点ける」「LED を消す」をプログラムで繰り返し実行することで実現します。</p>
-        <ul>
-          <li>参考：<a href="https://ja.wikipedia.org/wiki/%E7%99%BA%E5%85%89%E3%83%80%E3%82%A4%E3%82%AA%E3%83%BC%E3%83%89">LED（発光ダイオード）</a></li>
-        </ul>
+        <p>「L チカ」とは、LED（発光ダイオード）<span class="footnote"><a href="https://ja.wikipedia.org/wiki/%E7%99%BA%E5%85%89%E3%83%80%E3%82%A4%E3%82%AA%E3%83%BC%E3%83%89">https://ja.wikipedia.org/wiki/発光ダイオード</a></span>を点けたり消したりチカチカ点滅させることです。今回は「LED を点ける」「LED を消す」をプログラムで繰り返し実行することで実現します。</p>
       </section>
       <section class="level2" aria-labelledby="led">
         <h2 id="led">LED</h2>
         <ul>
-          <li><a href="https://ja.wikipedia.org/wiki/%E7%99%BA%E5%85%89%E3%83%80%E3%82%A4%E3%82%AA%E3%83%BC%E3%83%89">LED（発光ダイオード）</a></li>
           <li><a href="https://www.marutsu.co.jp/pc/static/large_order/led">LED の使い方</a></li>
         </ul>
         <section class="level3" aria-labelledby="ヒント-led-の電圧">
@@ -246,7 +242,7 @@
         <p>Raspi に実装されている 40 本のピンヘッダから GPIO を利用することができます。</p>
         <p>CHIRIMEN Raspi、Raspi Zero では Raspi が提供する 40 本のピンヘッダのうち、下記緑色のピン(合計 17 本)が利用可能です。CHIRIMEN micro:bitでは<a href="https://chirimen.org/chirimen-micro-bit/guidebooks/diff_rpi3.html#%E4%BD%BF%E7%94%A8%E3%81%A7%E3%81%8D%E3%82%8Bgpio%E3%83%9D%E3%83%BC%E3%83%88">こちらのページ</a>に記載されている端子が利用可能です。</p>
         <p>Raspiやmicro:bit の GPIO 端子は、GND 端子との間に、0V もしくは 3.3V の電圧を印加(出力)したり、逆に 0V もしくは 3.3V の電圧を検知(入力)したりすることができます。LED は数 mA の電流を流すことによって点灯できる電子部品のため、印加する電圧を 3.3V(点灯)、0V(消灯) と変化させることで L チカが実現できるのです。</p>
-        <p>詳しくは<a href="https://tool-lab.com/make/raspberrypi-startup-22/">こちらのサイトの解説</a>などを参考にしてみましょう。</p>
+        <p>詳しくは<a href="https://tool-lab.com/make/raspberrypi-startup-22/">ツール・ラボ/第22回 Raspberry PiのGPIO概要</a>などを参考にしてみましょう。</p>
         <section class="level3" aria-labelledby="raspberry-piのピン配置図">
           <h3 id="raspberry-piのピン配置図">Raspberry Piのピン配置図</h3>
           <figure>
@@ -271,9 +267,7 @@
             GPIOポートを入力モードで使用する場合、ポートが解放状態(電気的に切り離されている状態)のときに設定される値があります。
             プルアップは1、プルダウンは0になります。　Raspberry Piのピン配置図に書かれているPU,PDがその設定値です。micro:bitではすべてプルダウンに設定されていますが、GPIOポート初期化時にプルアップに設定することもできます。
           </p>
-          <ul>
-            <li><a href="https://voltechno.com/blog/pullup-pulldown/">より詳しく知る(voltechno)</a></li>
-          </ul>
+          <p>より詳しく知りたい場合は <a href="https://voltechno.com/blog/pullup-pulldown/">プルアップ抵抗・プルダウン抵抗とは？電子回路に必須の考え方/voltechno</a> を参照してください。</p>
           <hr class="page-wrap">
         </section>
       </section>
@@ -364,7 +358,7 @@
           <section class="level4" aria-labelledby="ポーリングとは">
             <h4 id="ポーリングとは">ポーリングとは</h4>
             <p>
-              様々な情報や値の取得や入力のための基本的な機能・関数は、入力を指定した瞬間、一回きり取得するだけのものがほとんどです。そこで、無限ループをつくりこの中で一回きりの入力を定期的に繰り返すことで、入力の変化を読み取る　ということがよく行われます。このような処理を一般にポーリングと呼びます。 (<a href="https://ja.wikipedia.org/wiki/%E3%83%9D%E3%83%BC%E3%83%AA%E3%83%B3%E3%82%B0_(%E6%83%85%E5%A0%B1)">wikipedia:ポーリング</a>)
+              様々な情報や値の取得や入力のための基本的な機能・関数は、入力を指定した瞬間、一回きり取得するだけのものがほとんどです。そこで、無限ループをつくりこの中で一回きりの入力を定期的に繰り返すことで、入力の変化を読み取る　ということがよく行われます。このような処理を一般にポーリング<span class="footnote"><a href="https://ja.wikipedia.org/wiki/%E3%83%9D%E3%83%BC%E3%83%AA%E3%83%B3%E3%82%B0_(%E6%83%85%E5%A0%B1)">https://ja.wikipedia.org/wiki/ポーリング_(情報)</a></span>と呼びます。
               ポーリングはセンサーの情報入力だけでなく、たとえば電子メールの到着を通知するために定期的にメールサーバにメール着信数を確認する　といった、ネットワークサービスでの処理など様々なシステムで広く使われています。
             </p>
           </section>
@@ -517,9 +511,6 @@
       <section class="level2" aria-labelledby="b-i2cdetectで接続がうまくいったか確認する">
         <h2 id="b-i2cdetectで接続がうまくいったか確認する">b. i2cdetectで接続がうまくいったか確認する</h2>
         <p><code>i2cdetect</code> を使って SlaveAddress を確認し、正しく接続・認識できているか確かめてみましょう。ターミナルを起動して下記コマンドを入力してみてください。</p>
-        <ul>
-          <li><a href="https://tutorial.chirimen.org/ty51822r3/i2cdetect">ic2 detectとは</a></li>
-        </ul>
         <section class="level3" aria-labelledby="コマンドラインから">
           <h3 id="コマンドラインから">コマンドラインから</h3>
           <pre class="language-sh"><code class="language-sh">i2cdetect -y -r 1</code></pre>
@@ -530,7 +521,10 @@
           <h3 id="i2cdetect-webapp">i2cdetect webApp</h3>
           <section class="level4" aria-labelledby="raspberry-pi">
             <h4 id="raspberry-pi">Raspberry Pi</h4>
-            <p>SlaveAddress を確認する i2cdetect には WebI2C(後述) を使って実装したwebApp版もあります。<a href="https://r.chirimen.org/i2cdetect">https://r.chirimen.org/i2cdetect</a> をご利用ください。ただし、WebI2C 版 i2cdetect を利用中は他のページから I2C デバイスを操作できません。確認が済んだらタブを閉じるようにしましょう。</p>
+            <p>
+              SlaveAddress を確認する i2cdetect には WebI2C(後述) を使って実装したwebApp版もあります。<a href="https://r.chirimen.org/i2cdetect">https://r.chirimen.org/i2cdetect</a> をご利用ください。ただし、WebI2C 版 i2cdetect を利用中は他のペ
+              ージから I2C デバイスを操作できません。確認が済んだらタブを閉じるようにしましょう。
+            </p>
           </section>
           <section class="level4" aria-labelledby="raspberry-pizerow">
             <h4 id="raspberry-pizerow">Raspberry PiZeroW</h4>
@@ -698,16 +692,14 @@
           <h3 id="デバイスドライバーなしにsht30を使う">デバイスドライバーなしにSHT30を使う</h3>
           <p>デバイスドライバーはI2Cデバイスを簡単に使えるようにするライブラリでしかありませんので、ライブラリなしにWebI2CAPIを用いて直接デバイスを使うこともできます。運悪くデバイスドライバーが用意されていないI2Cデバイスを使いたい場合や、デバイスドライバーで省略されている機能を使いたい場合などのために、<a href="http://browserobo.github.io/WebI2C">Web I2C API</a>の振る舞いを理解しておきましょう。</p>
           <p>まず、デバイスドライバーなしに使うにはそのデバイスのデータシートをよく読み込みながら開発する必要があります。</p>
-          <p><strong><a href="https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/2_Humidity_Sensors/Datasheets/Sensirion_Humidity_Sensors_SHT3x_Datasheet_digital.pdf">SHT30データシート</a></strong></p>
-          <p><a href="https://github.com/chirimen-oh/chirimen-drivers/tree/master/packages/sht30/sht30.js">ドライバーライブラリを GitHub で見てみる</a></p>
-          <p>それではSHT30ドライバのコードを見てみましょう。</p>
+          <p>それでは<a href="https://github.com/chirimen-oh/chirimen-drivers/tree/master/packages/sht30/sht30.js">SHT30ドライバのコード</a>を見てみましょう。</p>
           <ul>
             <li>初期化 <code>init()</code></li>
           </ul>
           <pre class="language-js"><code class="language-js"><span class="token keyword control-flow">if</span> <span class="token punctuation">(</span><span class="token operator">!</span>slaveAddress<span class="token punctuation">)</span><span class="token punctuation">{</span>
 		slaveAddress <span class="token operator">=</span> <span class="token number">0x44</span><span class="token punctuation">;</span>
 <span class="token punctuation">}</span></code></pre>
-          <p>データシート（９ページ)に記載の通り、ドライバでは　指定がない場合スレーブアドレス0x44を指定して通信を開始しています。</p>
+          <p><a href="https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/2_Humidity_Sensors/Datasheets/Sensirion_Humidity_Sensors_SHT3x_Datasheet_digital.pdf">SHT30データシート</a> の９ページに記載の通り、ドライバでは指定がない場合スレーブアドレス0x44を指定して通信を開始しています。</p>
           <ul>
             <li>データの読み取り <code>readData()</code></li>
           </ul>
@@ -735,7 +727,7 @@
         これまでのチュートリアルでは、いずれもそのコンピュータに直接接続されたデバイスを使うものでした。このようなシステムは「スタンドアロン」と呼ばれます。
         今までは、ウェブブラウザを使っていたのに、実はウェブの重要な機能～インターネット上の情報基盤WWWを活用したシステムを作っていなかったのです。（開発環境としてはgithubやcodesandboxなどWWW上の情報サービスを活用していますが）
       </p>
-      <p>このようなインターネットを活用するシステムのことをIoT (Internet of Thingの略)と呼びます。ただし単にPCやスマホで使うウェブサービスがIoTと呼ばれることがありません。チュートリアルで学んだようなセンサーやアクチュエータがシステムに組み込まれ、物理的なモノと相互作用するようなものを特にIoTと呼びます。（なお、WWWを用いずネットワーク部のインターネットだけを使ったものでもIoTと呼びます。詳しくは<a href="https://ja.wikipedia.org/wiki/%E3%83%A2%E3%83%8E%E3%81%AE%E3%82%A4%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8D%E3%83%83%E3%83%88">wiki</a>や、<a href="https://smartiot-forum.jp/application/files/5315/8642/5503/iot-jinzai-text_verR0202.pdf">こちらの資料</a>なども参考にしてください）</p>
+      <p>このようなインターネットを活用するシステムのことをIoT (Internet of Thingの略)と呼びます。ただし単にPCやスマホで使うウェブサービスがIoTと呼ばれることがありません。チュートリアルで学んだようなセンサーやアクチュエータがシステムに組み込まれ、物理的なモノと相互作用するようなものを特にIoTと呼びます。（なお、WWWを用いずネットワーク部のインターネットだけを使ったものでもIoTと呼びます。詳しくはwiki<span class="footnote"><a href="https://ja.wikipedia.org/wiki/%E3%83%A2%E3%83%8E%E3%81%AE%E3%82%A4%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8D%E3%83%83%E3%83%88">https://ja.wikipedia.org/wiki/モノのインターネット</a></span>や、<a href="https://smartiot-forum.jp/application/files/5315/8642/5503/iot-jinzai-text_verR0202.pdf">総務省「IoT機器等の電波利用システムの適正利用のためのICT人材育成事業」における講習会テキスト</a>なども参考にしてください）</p>
       <section class="level2" aria-labelledby="websocketとpubsub-services">
         <h2 id="websocketとpubsub-services">webSocketとpub/sub services</h2>
         <section class="level3" aria-labelledby="システム構成">
@@ -782,19 +774,18 @@
             <p>IoTにはrelayServerの機能を持つウェブサイトが必要になりますが、これを誰かが運営しなければなりません。実習やプロトタイピングのためにこのようなサイトを自分たちで立ち上げるのはかなり大変ですが、インターネット上では既にいくつもの事業者がrelayServerサービスを提供しています。</p>
             <p>今回はCHIRIMEN環境の試験用に、CHIRIMEN用に用意された検証用サービス(chirimentest)を使うことにしますが、いくつかある事業者間でサービスの内容に差異があります。サイトごとの差異は主に接続できる端末の管理と情報の取り扱いに関する機能になります。</p>
             <p><a href="https://chirimen.org/remote-connection/">relayServer.js</a>は、relayServerサービスによる差異を吸収し複数の事業者を自由に切り替えられ、webSocketの標準API仕様に沿った作法でwebApps(含Node.jsプログラム)間の通信を簡単に使えるようにするライブラリです。</p>
-            <section class="level5" aria-labelledby="プログラムの流れ">
-              <h5 id="プログラムの流れ">プログラムの流れ</h5>
-              <section class="level6" aria-labelledby="初期化受信側送信側共通の処理">
-                <h6 id="初期化受信側送信側共通の処理">初期化（受信側、送信側共通の処理</h6>
-                <p><a href="https://chirimen.org/remote-connection/#%E4%BD%BF%E7%94%A8%E6%96%B9%E6%B3%95">詳しくはこちらを参照</a></p>
-                <pre class="language-javascript"><code class="language-javascript"><span class="token keyword module">import</span> <span class="token imports"><span class="token punctuation">{</span><span class="token maybe-class-name">RelayServer</span><span class="token punctuation">}</span></span> <span class="token keyword module">from</span> <span class="token string">"https://chirimen.org/remote-connection/js/beta/RelayServer.js"</span><span class="token punctuation">;</span>
+          </section>
+          <section class="level4" aria-labelledby="relayserverjs-を使ったプログラムの流れ">
+            <h4 id="relayserverjs-を使ったプログラムの流れ">relayServer.js を使ったプログラムの流れ</h4>
+            <section class="level5" aria-labelledby="初期化受信側送信側共通の処理">
+              <h5 id="初期化受信側送信側共通の処理">初期化（受信側、送信側共通の処理</h5>
+              <pre class="language-javascript"><code class="language-javascript"><span class="token keyword module">import</span> <span class="token imports"><span class="token punctuation">{</span><span class="token maybe-class-name">RelayServer</span><span class="token punctuation">}</span></span> <span class="token keyword module">from</span> <span class="token string">"https://chirimen.org/remote-connection/js/beta/RelayServer.js"</span><span class="token punctuation">;</span>
 <span class="token keyword">var</span> relay <span class="token operator">=</span> <span class="token function"><span class="token maybe-class-name">RelayServer</span></span><span class="token punctuation">(</span><span class="token string">"achex"</span><span class="token punctuation">,</span> <span class="token string">"chirimenSocket"</span> <span class="token punctuation">)</span><span class="token punctuation">;</span></code></pre>
-                <p>
-                  import文でライブラリRelayServer.jsを読み込んだ後、relayServiceのひとつ<strong>achex</strong>に接続しています。
-                  RelayServerの第二引数<code>("chirimenSocket")</code>はそのサービスを使うためのトークンですが、<strong>achex</strong>は任意の文字列で利用できてます。
-                </p>
-                <p><em>Node.jsでは第三,第四引数が必要になります (後述)</em></p>
-              </section>
+              <p>
+                import文でライブラリRelayServer.jsを読み込んだ後、relayServiceのひとつ<strong>achex</strong>に接続しています。
+                RelayServerの第二引数<code>("chirimenSocket")</code>はそのサービスを使うためのトークンですが、<strong>achex</strong>は任意の文字列で利用できてます。
+              </p>
+              <p><em>Node.jsでは第三,第四引数が必要になります (後述)</em></p>
             </section>
             <section class="level5" aria-labelledby="チャンネルの作成">
               <h5 id="チャンネルの作成">チャンネルの作成</h5>
@@ -839,7 +830,7 @@
           </section>
           <section class="level4" aria-labelledby="セキュリティを考えよう">
             <h4 id="セキュリティを考えよう">セキュリティを考えよう</h4>
-            <p>relayServerを使うということは、情報をインターネット上のウェブサイトに送信することになります。すると このウェブサイトがその情報をどのように取り扱うのかを理解しておく必要があります。achexは無料で使え　しかもユーザ登録も不要です。つまりこのサイトに送信した情報は誰でも見ることができてしまうということです。（ただし、トークンとチャンネルを知る必要がある。これがachexのセキュリティレベル）今回は個人情報などのセキュリティを考慮する必要がない、チュートリアルで使うセンシングデータを送るだけですので問題ありませんが、セキュリティを考慮する必要がある多くの用途ではそのセキュリティ基準に適合したサイトを契約して利用する、もしくは自分でそのようなサイトを立てるなどの必要が出てきます。relayServer.jsでも<a href="https://chirimen.org/remote-connection/#%E3%82%B5%E3%83%BC%E3%83%93%E3%82%B9%E3%81%94%E3%81%A8%E3%81%AE%E5%88%A9%E7%94%A8%E6%96%B9%E6%B3%95">いくつかの商用サイト</a>の比較と使用方法が記載されているので参考にしてください。</p>
+            <p>relayServerを使うということは、情報をインターネット上のウェブサイトに送信することになります。すると このウェブサイトがその情報をどのように取り扱うのかを理解しておく必要があります。achexは無料で使え　しかもユーザ登録も不要です。つまりこのサイトに送信した情報は誰でも見ることができてしまうということです。（ただし、トークンとチャンネルを知る必要がある。これがachexのセキュリティレベル）今回は個人情報などのセキュリティを考慮する必要がない、チュートリアルで使うセンシングデータを送るだけですので問題ありませんが、セキュリティを考慮する必要がある多くの用途ではそのセキュリティ基準に適合したサイトを契約して利用する、もしくは自分でそのようなサイトを立てるなどの必要が出てきます。relayServer.jsでもいくつかの商用サイトの比較と使用方法が記載されているので参考にしてください。</p>
           </section>
           <section class="level4" aria-labelledby="nodejsでの利用">
             <h4 id="nodejsでの利用">Node.jsでの利用</h4>

--- a/pizero-book/docs/chirimenGeneric.md
+++ b/pizero-book/docs/chirimenGeneric.md
@@ -26,13 +26,9 @@ CHIRIMEN とは、Webの標準的な技術・ブラウザやNode.js等で実行�
 
 ## そもそも「L チカ」って何？
 
-「L チカ」とは、LED を点けたり消したりチカチカ点滅させることです。今回は「LED を点ける」「LED を消す」をプログラムで繰り返し実行することで実現します。
-
-- 参考：[LED（発光ダイオード）](https://ja.wikipedia.org/wiki/%E7%99%BA%E5%85%89%E3%83%80%E3%82%A4%E3%82%AA%E3%83%BC%E3%83%89)
-
+「L チカ」とは、LED（発光ダイオード）<span class="footnote">https://ja.wikipedia.org/wiki/発光ダイオード</span>を点けたり消したりチカチカ点滅させることです。今回は「LED を点ける」「LED を消す」をプログラムで繰り返し実行することで実現します。
 
 ## LED
-- [LED（発光ダイオード）](https://ja.wikipedia.org/wiki/%E7%99%BA%E5%85%89%E3%83%80%E3%82%A4%E3%82%AA%E3%83%BC%E3%83%89)
 - [LED の使い方](https://www.marutsu.co.jp/pc/static/large_order/led)
 
 ### ヒント: LED の電圧
@@ -171,7 +167,7 @@ CHIRIMEN Raspi、Raspi Zero では Raspi が提供する 40 本のピンヘッ�
 
 Raspiやmicro:bit の GPIO 端子は、GND 端子との間に、0V もしくは 3.3V の電圧を印加(出力)したり、逆に 0V もしくは 3.3V の電圧を検知(入力)したりすることができます。LED は数 mA の電流を流すことによって点灯できる電子部品のため、印加する電圧を 3.3V(点灯)、0V(消灯) と変化させることで L チカが実現できるのです。
 
-詳しくは[こちらのサイトの解説](https://tool-lab.com/make/raspberrypi-startup-22/)などを参考にしてみましょう。
+詳しくは[ツール・ラボ/第22回 Raspberry PiのGPIO概要](https://tool-lab.com/make/raspberrypi-startup-22/)などを参考にしてみましょう。
 
 ### Raspberry Piのピン配置図
 
@@ -187,7 +183,7 @@ Raspberry Piの端子と同じ配列です。
 GPIOポートを入力モードで使用する場合、ポートが解放状態(電気的に切り離されている状態)のときに設定される値があります。
 プルアップは1、プルダウンは0になります。　Raspberry Piのピン配置図に書かれているPU,PDがその設定値です。micro:bitではすべてプルダウンに設定されていますが、GPIOポート初期化時にプルアップに設定することもできます。
 
-* [より詳しく知る(voltechno)](https://voltechno.com/blog/pullup-pulldown/)
+より詳しく知りたい場合は [プルアップ抵抗・プルダウン抵抗とは？電子回路に必須の考え方/voltechno](https://voltechno.com/blog/pullup-pulldown/) を参照してください。
 
 <hr class="page-wrap" />
 
@@ -286,7 +282,8 @@ main();
 こちらはGPIOポートの入力値を一回きり単発で取得する単純入力機能と、ポーリングの組み合わせです。
 
 #### ポーリングとは
-様々な情報や値の取得や入力のための基本的な機能・関数は、入力を指定した瞬間、一回きり取得するだけのものがほとんどです。そこで、無限ループをつくりこの中で一回きりの入力を定期的に繰り返すことで、入力の変化を読み取る　ということがよく行われます。このような処理を一般にポーリングと呼びます。 ([wikipedia:ポーリング](https://ja.wikipedia.org/wiki/%E3%83%9D%E3%83%BC%E3%83%AA%E3%83%B3%E3%82%B0_(%E6%83%85%E5%A0%B1)))
+
+様々な情報や値の取得や入力のための基本的な機能・関数は、入力を指定した瞬間、一回きり取得するだけのものがほとんどです。そこで、無限ループをつくりこの中で一回きりの入力を定期的に繰り返すことで、入力の変化を読み取る　ということがよく行われます。このような処理を一般にポーリング<span class="footnote">https://ja.wikipedia.org/wiki/ポーリング_(情報)</span>と呼びます。
 ポーリングはセンサーの情報入力だけでなく、たとえば電子メールの到着を通知するために定期的にメールサーバにメール着信数を確認する　といった、ネットワークサービスでの処理など様々なシステムで広く使われています。
 
 #### GPIOの単純入力関数
@@ -424,8 +421,6 @@ I2Cデバイスは一般的に小さなチップ部品です。下の拡大写�
 
 `i2cdetect` を使って SlaveAddress を確認し、正しく接続・認識できているか確かめてみましょう。ターミナルを起動して下記コマンドを入力してみてください。
 
-* [ic2 detectとは](https://tutorial.chirimen.org/ty51822r3/i2cdetect)
-
 ### コマンドラインから
 ```sh
 i2cdetect -y -r 1
@@ -436,7 +431,8 @@ i2cdetect -y -r 1
 
 ### i2cdetect webApp
 #### Raspberry Pi
-SlaveAddress を確認する i2cdetect には WebI2C(後述) を使って実装したwebApp版もあります。[https://r.chirimen.org/i2cdetect](https://r.chirimen.org/i2cdetect) をご利用ください。ただし、WebI2C 版 i2cdetect を利用中は他のページから I2C デバイスを操作できません。確認が済んだらタブを閉じるようにしましょう。
+SlaveAddress を確認する i2cdetect には WebI2C(後述) を使って実装したwebApp版もあります。https://r.chirimen.org/i2cdetect をご利用ください。ただし、WebI2C 版 i2cdetect を利用中は他のペ
+ージから I2C デバイスを操作できません。確認が済んだらタブを閉じるようにしましょう。
 
 #### Raspberry PiZeroW
 Raspberry PiZeroWでは、[ターミナルウィンド](https://chirimen.org/PiZeroWebSerialConsole/PiZeroWebSerialConsole.html)⇒CHIRIMEN Panel⇒i2c detect　でコマンドラインのショートカットが使えます。
@@ -615,11 +611,7 @@ const { humidity, temperature } = await sht30.readData();
 
 まず、デバイスドライバーなしに使うにはそのデバイスのデータシートをよく読み込みながら開発する必要があります。
 
-**[SHT30データシート](https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/2_Humidity_Sensors/Datasheets/Sensirion_Humidity_Sensors_SHT3x_Datasheet_digital.pdf)**
-
-[ドライバーライブラリを GitHub で見てみる](https://github.com/chirimen-oh/chirimen-drivers/tree/master/packages/sht30/sht30.js)
-
-それではSHT30ドライバのコードを見てみましょう。
+それでは[SHT30ドライバのコード](https://github.com/chirimen-oh/chirimen-drivers/tree/master/packages/sht30/sht30.js)を見てみましょう。
 
 * 初期化 `init()`
 ```js
@@ -627,7 +619,8 @@ if (!slaveAddress){
 		slaveAddress = 0x44;
 }
 ```
-データシート（９ページ)に記載の通り、ドライバでは　指定がない場合スレーブアドレス0x44を指定して通信を開始しています。
+
+[SHT30データシート](https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/2_Humidity_Sensors/Datasheets/Sensirion_Humidity_Sensors_SHT3x_Datasheet_digital.pdf) の９ページに記載の通り、ドライバでは指定がない場合スレーブアドレス0x44を指定して通信を開始しています。
 
 * データの読み取り `readData()`
 ```js
@@ -653,7 +646,7 @@ var humidity = 100 * (mdata[3] * 256 + mdata[4]) / 65535.0;
 これまでのチュートリアルでは、いずれもそのコンピュータに直接接続されたデバイスを使うものでした。このようなシステムは「スタンドアロン」と呼ばれます。
 今までは、ウェブブラウザを使っていたのに、実はウェブの重要な機能～インターネット上の情報基盤WWWを活用したシステムを作っていなかったのです。（開発環境としてはgithubやcodesandboxなどWWW上の情報サービスを活用していますが）
 
-このようなインターネットを活用するシステムのことをIoT (Internet of Thingの略)と呼びます。ただし単にPCやスマホで使うウェブサービスがIoTと呼ばれることがありません。チュートリアルで学んだようなセンサーやアクチュエータがシステムに組み込まれ、物理的なモノと相互作用するようなものを特にIoTと呼びます。（なお、WWWを用いずネットワーク部のインターネットだけを使ったものでもIoTと呼びます。詳しくは[wiki](https://ja.wikipedia.org/wiki/%E3%83%A2%E3%83%8E%E3%81%AE%E3%82%A4%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8D%E3%83%83%E3%83%88)や、[こちらの資料](https://smartiot-forum.jp/application/files/5315/8642/5503/iot-jinzai-text_verR0202.pdf)なども参考にしてください）
+このようなインターネットを活用するシステムのことをIoT (Internet of Thingの略)と呼びます。ただし単にPCやスマホで使うウェブサービスがIoTと呼ばれることがありません。チュートリアルで学んだようなセンサーやアクチュエータがシステムに組み込まれ、物理的なモノと相互作用するようなものを特にIoTと呼びます。（なお、WWWを用いずネットワーク部のインターネットだけを使ったものでもIoTと呼びます。詳しくはwiki<span class="footnote">https://ja.wikipedia.org/wiki/モノのインターネット</span>や、[総務省「IoT機器等の電波利用システムの適正利用のためのICT人材育成事業」における講習会テキスト](https://smartiot-forum.jp/application/files/5315/8642/5503/iot-jinzai-text_verR0202.pdf)なども参考にしてください）
 
 ## webSocketとpub/sub services
 ### システム構成
@@ -699,9 +692,9 @@ IoTにはrelayServerの機能を持つウェブサイトが必要になります
 
 [relayServer.js](https://chirimen.org/remote-connection/)は、relayServerサービスによる差異を吸収し複数の事業者を自由に切り替えられ、webSocketの標準API仕様に沿った作法でwebApps(含Node.jsプログラム)間の通信を簡単に使えるようにするライブラリです。
 
-##### プログラムの流れ
-###### 初期化（受信側、送信側共通の処理
-[詳しくはこちらを参照](https://chirimen.org/remote-connection/#使用方法)
+#### relayServer.js を使ったプログラムの流れ
+
+##### 初期化（受信側、送信側共通の処理
 
 ```javascript
 import {RelayServer} from "https://chirimen.org/remote-connection/js/beta/RelayServer.js";
@@ -738,7 +731,7 @@ var relay = RelayServer("achex", "chirimenSocket" );
 
 #### セキュリティを考えよう
 
-relayServerを使うということは、情報をインターネット上のウェブサイトに送信することになります。すると このウェブサイトがその情報をどのように取り扱うのかを理解しておく必要があります。achexは無料で使え　しかもユーザ登録も不要です。つまりこのサイトに送信した情報は誰でも見ることができてしまうということです。（ただし、トークンとチャンネルを知る必要がある。これがachexのセキュリティレベル）今回は個人情報などのセキュリティを考慮する必要がない、チュートリアルで使うセンシングデータを送るだけですので問題ありませんが、セキュリティを考慮する必要がある多くの用途ではそのセキュリティ基準に適合したサイトを契約して利用する、もしくは自分でそのようなサイトを立てるなどの必要が出てきます。relayServer.jsでも[いくつかの商用サイト](https://chirimen.org/remote-connection/#%E3%82%B5%E3%83%BC%E3%83%93%E3%82%B9%E3%81%94%E3%81%A8%E3%81%AE%E5%88%A9%E7%94%A8%E6%96%B9%E6%B3%95)の比較と使用方法が記載されているので参考にしてください。
+relayServerを使うということは、情報をインターネット上のウェブサイトに送信することになります。すると このウェブサイトがその情報をどのように取り扱うのかを理解しておく必要があります。achexは無料で使え　しかもユーザ登録も不要です。つまりこのサイトに送信した情報は誰でも見ることができてしまうということです。（ただし、トークンとチャンネルを知る必要がある。これがachexのセキュリティレベル）今回は個人情報などのセキュリティを考慮する必要がない、チュートリアルで使うセンシングデータを送るだけですので問題ありませんが、セキュリティを考慮する必要がある多くの用途ではそのセキュリティ基準に適合したサイトを契約して利用する、もしくは自分でそのようなサイトを立てるなどの必要が出てきます。relayServer.jsでもいくつかの商用サイトの比較と使用方法が記載されているので参考にしてください。
 
 #### Node.jsでの利用
 

--- a/pizero-book/docs/readme.html
+++ b/pizero-book/docs/readme.html
@@ -26,11 +26,7 @@
                 <li>Pi Zero <strong>2</strong> W: <a href="https://raspberry-pi.ksyic.com/main/index/pdp.id/851/pdp.open/851">ケイエスワイ</a></li>
               </ul>
             </li>
-            <li><a href="https://github.com/chirimen-oh/chirimen-lite/releases">Raspberry Pi OS LiteをUSB Serialで使用可能にしたイメージ</a>を書き込んだmicroSDカード
-              <ul>
-                <li>講習会では書き込み済みmicroSDが配布されると思いますが、自分で作る場合は<a href="../raspi/sdcard2">こちら</a>や<a href="../raspi/sdcard">こちら</a>(書き込むべきイメージはLite版の方です。(<a href="https://github.com/chirimen-oh/chirimen-lite/releases">これを書き込みます</a>))</li>
-              </ul>
-            </li>
+            <li><a href="https://github.com/chirimen-oh/chirimen-lite/releases">Raspberry Pi OS LiteをUSB Serialで使用可能にしたイメージ</a>を書き込んだmicroSDカード</li>
             <li>ブラウザの載ったパソコン
               <ul>
                 <li>Windows 10 PC
@@ -143,7 +139,7 @@
           <h3 id="note">Note:</h3>
           <ul>
             <li>
-              <p>CHIRIMEN Raspberry Pi Zero版では<a href="https://www.raspberrypi.com/software/operating-systems/">Raspberry Pi OS Lite</a>(Linux)をコマンドラインインターフェース(CLI)・シェル(bash)で操作します。</p>
+              <p>CHIRIMEN Raspberry Pi Zero版では<a href="https://www.raspberrypi.com/software/operating-systems/">Raspberry Pi OS Lite</a>(Linux)を<a href="https://atmarkit.itmedia.co.jp/ait/articles/1602/19/news025.html">コマンドラインインターフェース(CLI)</a>・<a href="https://atmarkit.itmedia.co.jp/ait/articles/1603/02/news016.html">シェル(bash)</a>で操作します。</p>
               <ul>
                 <li>ただしこの講習で使うコマンドはごくわずかです。
                   <ul>
@@ -153,12 +149,6 @@
                 </li>
                 <li>その他のほとんどの操作（コマンド）は、ターミナルウィンドやそこから起動される別画面のGUIがコマンド操作を代行しています。図1.1のGUIを操作するとコンソールにコマンドが入力されるのがわかると思います。</li>
               </ul>
-            </li>
-            <li>
-              <p><a href="https://atmarkit.itmedia.co.jp/ait/articles/1602/19/news025.html">CLIとは</a></p>
-            </li>
-            <li>
-              <p><a href="https://atmarkit.itmedia.co.jp/ait/articles/1603/02/news016.html">シェルとコマンドプロンプト</a></p>
             </li>
             <li>
               <p>もしもあなたがlinuxのシェルコンソール画面に慣れている場合は、ターミナルウィンドのコンソールにその他のシェル(bash)コマンドをタイプして使用することもできます。</p>
@@ -332,8 +322,7 @@
           <li>コンソール部をクリックして、入力可能状態にしてから、以下の文字を入力します。</li>
           <li><code>node hello.js</code> ENTERキー
             <ul>
-              <li><strong>node</strong> はJavaScriptのコードを実行する<a href="https://ja.wikipedia.org/wiki/%E3%82%A4%E3%83%B3%E3%82%BF%E3%83%97%E3%83%AA%E3%82%BF">インタープリタ</a></li>
-              <li><a href="https://atmarkit.itmedia.co.jp/ait/articles/1102/28/news105.html">nodeコマンドについて</a></li>
+              <li><a href="https://atmarkit.itmedia.co.jp/ait/articles/1102/28/news105.html"><strong>node</strong></a> はJavaScriptのコードを実行するインタープリタ<span class="footnote"><a href="https://ja.wikipedia.org/wiki/%E3%82%A4%E3%83%B3%E3%82%BF%E3%83%97%E3%83%AA%E3%82%BF">https://ja.wikipedia.org/wiki/インタプリタ</a></span></li>
             </ul>
           </li>
           <li>LED が点滅すれば完成です 🎉</li>
@@ -345,11 +334,7 @@
     <section class="level1" aria-labelledby="raspberry-pi-について">
       <h1 id="raspberry-pi-について">Raspberry Pi について</h1>
       <ul>
-        <li>教育・学習用として設計されたシングルボードコンピュータ
-          <ul>
-            <li><a href="https://elchika.com/dic/%E3%82%B7%E3%83%B3%E3%82%B0%E3%83%AB%E3%83%9C%E3%83%BC%E3%83%89%E3%82%B3%E3%83%B3%E3%83%94%E3%83%A5%E3%83%BC%E3%82%BF/">シングルボードコンピュータ～PC・スマホとの違い</a></li>
-          </ul>
-        </li>
+        <li>教育・学習用として設計されたシングルボードコンピュータ<span class="footnote"><a href="https://elchika.com/dic/%E3%82%B7%E3%83%B3%E3%82%B0%E3%83%AB%E3%83%9C%E3%83%BC%E3%83%89%E3%82%B3%E3%83%B3%E3%83%94%E3%83%A5%E3%83%BC%E3%82%BF/">https://elchika.com/dic/シングルボードコンピュータ/</a></span></li>
         <li>Linuxが動作するシングルボードコンピュータとして、安価でとても高いシェアを持ち世界中で容易に入手できる</li>
         <li>今回使用するRaspberry Pi ZeroWは、その中でも特に安価(<a href="https://www.switch-science.com/catalog/3200/">2000円以下</a>)で小型・低消費電力の機種、HDMI出力はあるもののブラウザを動かすだけの処理能力がありませんが、IoTのエッジデバイス（センサーやアクチュエータが載ったデバイスでディスプレイはあるとしても簡易のもの）には適しています。
           <ul>
@@ -669,11 +654,7 @@
           <li>ターミナルウィンドの<code>[CHIRIMEN Panel]</code>ボタンを押す</li>
           <li>出現したCHIRIMEN Panelの<code>[Get Examples]</code>ボタンを押す</li>
           <li>ID : adt7410を探します(上から5個目ぐらい)</li>
-          <li>回路図リンクを押すと回路図が出てきますので、回路を組みます。なお、接続は下の図のようになります。
-            <ul>
-              <li><a href="https://tutorial.chirimen.org/raspi/hellorealworld#section-2">センサーの極性に注意！</a></li>
-            </ul>
-          </li>
+          <li>回路図リンクを押すと回路図が出てきますので、回路を組みます。なお、接続は下の図のようになります。</li>
         </ul>
         <figure>
           <img src="../../pizero/imgs/pizero_temp.png" alt="PiZero温度センサー図">
@@ -692,15 +673,15 @@
             </ul>
           </li>
         </ul>
-        <hr class="page-wrap">
+        <section class="level4" aria-labelledby="センサーの極性に注意">
+          <h4 id="センサーの極性に注意">センサーの極性に注意</h4>
+          <pre class="language-text"><code class="language-text">温度センサー ADT7410 を用意した場合、図と同じように配線します。配線(特に電源線)を間違えるとセンサーが高熱になり火傷・破損するので注意してください。</code></pre>
+          <hr class="page-wrap">
+        </section>
         <section class="level3" aria-labelledby="i2cセンサーが認識されていることを確認する">
           <h3 id="i2cセンサーが認識されていることを確認する">I2Cセンサーが認識されていることを確認する</h3>
           <ul>
-            <li>CHIRIMEN Panelの<code>[i2c detect]</code>ボタンを押すと、<a href="https://akizukidenshi.com/download/ds/akizuki/AE-ADT7410_aw.pdf">ADT7410のI2Cアドレス</a>　0x<strong>48</strong>が表示されていればうまく接続されています。
-              <ul>
-                <li><a href="https://tutorial.chirimen.org/ty51822r3/i2cdetect">ic2 detectとは</a></li>
-              </ul>
-            </li>
+            <li>CHIRIMEN Panelの<a href="https://tutorial.chirimen.org/ty51822r3/i2cdetect"><code>[i2c detect]</code></a>ボタンを押すと、<a href="https://akizukidenshi.com/download/ds/akizuki/AE-ADT7410_aw.pdf">ADT7410のI2Cアドレス</a>　0x<strong>48</strong>が表示されていればうまく接続されています。</li>
           </ul>
           <pre>     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
 00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
@@ -777,11 +758,7 @@
           <ul>
             <li>CHIRIMEN Panelに戻り、ID : <strong>remote_gpio_led</strong>の行にある、<code>CSB EDIT</code>リンクをクリックする。
               <ul>
-                <li>CodeSandboxというオンラインのWebApp開発環境のウィンドが開き、PC側のコードが表示されています。編集もできます。
-                  <ul>
-                    <li>詳しい解説：<a href="https://csb-jp.github.io/">CodeSandbox ガイド</a></li>
-                  </ul>
-                </li>
+                <li><a href="https://csb-jp.github.io/">CodeSandbox</a>というオンラインのWebApp開発環境のウィンドが開き、PC側のコードが表示されています。編集もできます。</li>
                 <li>また、右側（もしくは右下）のフレームにはLEDを遠隔コントロールするためのwebAppが既に実行されています。</li>
                 <li>
                   webAppを使ってLEDが制御できることを確かめてみましょう。
@@ -920,7 +897,7 @@ import {RelayServer} from "./RelayServer.js";</code></pre>
           </ul>
         </li>
       </ul>
-      <p>その他、電子工作など一般的な知識は <a href="../reference.md">予備知識・資料集</a> や、<a href="../chirimenGeneric/">共通資料集</a>を参照してください。</p>
+      <p>その他、電子工作など一般的な知識は <a href="https://tutorial.chirimen.org/reference">予備知識・資料集</a> や、<a href="https://tutorial.chirimen.org/chirimengeneric/">共通資料集</a>を参照してください。</p>
       <hr class="page-wrap">
     </section>
     <section class="level1" aria-labelledby="chirimen-ブラウザー版との差異">

--- a/pizero-book/docs/readme.md
+++ b/pizero-book/docs/readme.md
@@ -16,7 +16,6 @@ CHIRIMEN Raspberry Pi Zero版 を用いたIoT実習資料です。
   * Pi Zero: [ケイエスワイ](https://raspberry-pi.ksyic.com/main/index/pdp.id/799/pdp.open/799), [秋月電子](https://akizukidenshi.com/catalog/g/gM-12961/), [スイッチサイエンス](https://www.switch-science.com/catalog/3646/), [マルツ](https://www.marutsu.co.jp/pc/i/1320453/)
   * Pi Zero **2** W: [ケイエスワイ](https://raspberry-pi.ksyic.com/main/index/pdp.id/851/pdp.open/851)
 * [Raspberry Pi OS LiteをUSB Serialで使用可能にしたイメージ](https://github.com/chirimen-oh/chirimen-lite/releases)を書き込んだmicroSDカード
-  * 講習会では書き込み済みmicroSDが配布されると思いますが、自分で作る場合は[こちら](../raspi/sdcard2)や[こちら](../raspi/sdcard)(書き込むべきイメージはLite版の方です。([これを書き込みます](https://github.com/chirimen-oh/chirimen-lite/releases)))
 * ブラウザの載ったパソコン
   * Windows 10 PC
     * ブラウザは標準のEdgeもしくはChromeを使います。
@@ -75,13 +74,11 @@ PiZero自体はディスプレイやキーボードを接続する必要はあ�
 
 ### Note:
 
-* CHIRIMEN Raspberry Pi Zero版では[Raspberry Pi OS Lite](https://www.raspberrypi.com/software/operating-systems/)(Linux)をコマンドラインインターフェース(CLI)・シェル(bash)で操作します。
+* CHIRIMEN Raspberry Pi Zero版では[Raspberry Pi OS Lite](https://www.raspberrypi.com/software/operating-systems/)(Linux)を[コマンドラインインターフェース(CLI)](https://atmarkit.itmedia.co.jp/ait/articles/1602/19/news025.html)・[シェル(bash)](https://atmarkit.itmedia.co.jp/ait/articles/1603/02/news016.html)で操作します。
   * ただしこの講習で使うコマンドはごくわずかです。
     * **node** コマンド(後述)
     * [CTRL+c](https://atmarkit.itmedia.co.jp/ait/articles/1708/04/news015_2.html)(CTRLキーとcを同時に押す:実行中のコマンドを終了させる)
   * その他のほとんどの操作（コマンド）は、ターミナルウィンドやそこから起動される別画面のGUIがコマンド操作を代行しています。図1.1のGUIを操作するとコンソールにコマンドが入力されるのがわかると思います。
-* [CLIとは](https://atmarkit.itmedia.co.jp/ait/articles/1602/19/news025.html)
-* [シェルとコマンドプロンプト](https://atmarkit.itmedia.co.jp/ait/articles/1603/02/news016.html)
 * もしもあなたがlinuxのシェルコンソール画面に慣れている場合は、ターミナルウィンドのコンソールにその他のシェル(bash)コマンドをタイプして使用することもできます。
   * たとえば ```ls -al``` とタイプするとおコンソール画面にディレクトリ内のファイルのリストが表示されます。
 * ターミナルウィンドの概要 (図1.1)
@@ -199,8 +196,7 @@ blink();
   * ```pi@raspberrypi:~/myApp$```
 * コンソール部をクリックして、入力可能状態にしてから、以下の文字を入力します。
 * ```node hello.js``` ENTERキー
-  * **node** はJavaScriptのコードを実行する[インタープリタ](https://ja.wikipedia.org/wiki/%E3%82%A4%E3%83%B3%E3%82%BF%E3%83%97%E3%83%AA%E3%82%BF)
-  * [nodeコマンドについて](https://atmarkit.itmedia.co.jp/ait/articles/1102/28/news105.html)
+  * [**node**](https://atmarkit.itmedia.co.jp/ait/articles/1102/28/news105.html) はJavaScriptのコードを実行するインタープリタ<span class="footnote">https://ja.wikipedia.org/wiki/インタプリタ</span>
 * LED が点滅すれば完成です 🎉
 * プログラムを止めるには、コンソール部で ```CTRL+c``` を押します。
 
@@ -208,8 +204,7 @@ blink();
 
 # Raspberry Pi について
 
-* 教育・学習用として設計されたシングルボードコンピュータ
-  * [シングルボードコンピュータ～PC・スマホとの違い](https://elchika.com/dic/%E3%82%B7%E3%83%B3%E3%82%B0%E3%83%AB%E3%83%9C%E3%83%BC%E3%83%89%E3%82%B3%E3%83%B3%E3%83%94%E3%83%A5%E3%83%BC%E3%82%BF/)
+* 教育・学習用として設計されたシングルボードコンピュータ<span class="footnote">https://elchika.com/dic/シングルボードコンピュータ/</span>
 * Linuxが動作するシングルボードコンピュータとして、安価でとても高いシェアを持ち世界中で容易に入手できる
 * 今回使用するRaspberry Pi ZeroWは、その中でも特に安価([2000円以下](https://www.switch-science.com/catalog/3200/))で小型・低消費電力の機種、HDMI出力はあるもののブラウザを動かすだけの処理能力がありませんが、IoTのエッジデバイス（センサーやアクチュエータが載ったデバイスでディスプレイはあるとしても簡易のもの）には適しています。
   * フルセットのブラウザが内蔵されたデバイスを作りたい場合は[CHIRIMEN Raspberry Pi版](../raspi/)が使用できます。
@@ -415,7 +410,6 @@ SHT30は温度に加えて湿度も測定できるI2C接続の多機能センサ
 * 出現したCHIRIMEN Panelの```[Get Examples]```ボタンを押す
 * ID : adt7410を探します(上から5個目ぐらい)
 * 回路図リンクを押すと回路図が出てきますので、回路を組みます。なお、接続は下の図のようになります。
-  * [センサーの極性に注意！](https://tutorial.chirimen.org/raspi/hellorealworld#section-2)
 
 ![PiZero温度センサー図](../../pizero/imgs/pizero_temp.png)
 * ```[JS GET]```ボタンを押すと、開発ディレクトリ(```~/myApp```)に、サンプルコードが保存されます。
@@ -424,12 +418,15 @@ SHT30は温度に加えて湿度も測定できるI2C接続の多機能センサ
     * ソースコードを見てみましょう
     * 今は編集不要ですが、サンプルをベースに応用プログラムを作るときには編集しましょう。
 
+#### センサーの極性に注意
+
+    温度センサー ADT7410 を用意した場合、図と同じように配線します。配線(特に電源線)を間違えるとセンサーが高熱になり火傷・破損するので注意してください。
+
 <hr class="page-wrap" />
 
 ### I2Cセンサーが認識されていることを確認する
 
-* CHIRIMEN Panelの```[i2c detect]```ボタンを押すと、[ADT7410のI2Cアドレス](https://akizukidenshi.com/download/ds/akizuki/AE-ADT7410_aw.pdf)　0x**48**が表示されていればうまく接続されています。
-  * [ic2 detectとは](https://tutorial.chirimen.org/ty51822r3/i2cdetect)
+* CHIRIMEN Panelの[```[i2c detect]```](https://tutorial.chirimen.org/ty51822r3/i2cdetect)ボタンを押すと、[ADT7410のI2Cアドレス](https://akizukidenshi.com/download/ds/akizuki/AE-ADT7410_aw.pdf)　0x**48**が表示されていればうまく接続されています。
 
 <pre>
      0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
@@ -487,8 +484,7 @@ Note: [モーター制御の回路](./#gpio-2)を組めば、そのまま遠隔�
 
 ### PC側のコードを準備し、実行する
 * CHIRIMEN Panelに戻り、ID : **remote_gpio_led**の行にある、```CSB EDIT```リンクをクリックする。
-  * CodeSandboxというオンラインのWebApp開発環境のウィンドが開き、PC側のコードが表示されています。編集もできます。
-    * 詳しい解説：[CodeSandbox ガイド](https://csb-jp.github.io/)
+  * [CodeSandbox](https://csb-jp.github.io/)というオンラインのWebApp開発環境のウィンドが開き、PC側のコードが表示されています。編集もできます。
   * また、右側（もしくは右下）のフレームにはLEDを遠隔コントロールするためのwebAppが既に実行されています。
   * webAppを使ってLEDが制御できることを確かめてみましょう。
 ![Code Sandbox Image](../../pizero/imgs/RC_CSB.svg){height=260}
@@ -575,7 +571,7 @@ CHIRIMEN for Raspberry Pi を利用するに際して、知っておくと良い
 - [JavaScript 初学者向け資料集](/js/)
   - JavaScript 1 Day 講習資料、JavaScript 本格入門書、チートシートなどはこちら
 
-その他、電子工作など一般的な知識は [予備知識・資料集](../reference.md) や、[共通資料集](../chirimenGeneric/)を参照してください。
+その他、電子工作など一般的な知識は [予備知識・資料集](https://tutorial.chirimen.org/reference) や、[共通資料集](https://tutorial.chirimen.org/chirimengeneric/)を参照してください。
 
 <hr class="page-wrap" />
 

--- a/pizero-book/themes/packages/@vivliostyle/theme-base/css/partial/footnote.css
+++ b/pizero-book/themes/packages/@vivliostyle/theme-base/css/partial/footnote.css
@@ -73,6 +73,10 @@
     margin-block: var(--vs-footnote--item-margin-block);
     margin-inline: var(--vs-footnote--item-margin-inline);
   }
+
+  .footnote > a {
+    text-decoration: none;
+  }
 }
 
 @-adapt-footnote-area {


### PR DESCRIPTION
close #5 

issue 側に書かれている箇所について修正。

### 脚注への対応

URLに日本語が含まれる場合、自動的にURLエンコードされてしまうのが、 `span` タグで指定する方法だとエンコードされずに脚注に入れられたので、一部のみ適用した。
またアンダーラインスタイルになるので、CSSで脚注リンクのテキストデコレーションを無効に設定追加。

同一キーワードで後で出現する方の脚注リンクは削除した。

