### PR TITLE
#36 脚注変更対応

### DIFF
--- a/pizero-book/docs/hello-world.html
+++ b/pizero-book/docs/hello-world.html
@@ -20,7 +20,7 @@
           </li>
           <li><a href="https://shop.sunhayato.co.jp/blogs/problem-solving/breadboard">ブレッドボードの使い方</a> (サンハヤト社)</li>
           <li>抵抗のカラーコードの読み方(JARL)<span class="footnote"><a href="https://www.jarl.org/Japanese/7_Technical/lib1/teikou.htm">https://www.jarl.org/Japanese/7_Technical/lib1/teikou.htm</a></span></li>
-          <li>その他、配線の基礎知識<span class="footnote">13 章の参考リンクから該当情報を参照ください</span></li>
+          <li>その他、配線の基礎知識（13 章 予備知識参照）</li>
         </ul>
         <div class="note" role="doc-note">
           <section class="level3" aria-labelledby="注意">

--- a/pizero-book/docs/hello-world.md
+++ b/pizero-book/docs/hello-world.md
@@ -7,7 +7,7 @@ PiZero とパーツを使って下の図の通りに配線します。
   * LED 基本ガイド (marutsu)<span class="footnote">https://www.marutsu.co.jp/pc/static/large_order/led</span>
 * [ブレッドボードの使い方](https://shop.sunhayato.co.jp/blogs/problem-solving/breadboard) (サンハヤト社)
 * 抵抗のカラーコードの読み方(JARL)<span class="footnote">https://www.jarl.org/Japanese/7_Technical/lib1/teikou.htm</span>
-* その他、配線の基礎知識<span class="footnote">13 章の参考リンクから該当情報を参照ください</span>
+* その他、配線の基礎知識（13 章 予備知識参照）
 
 
 <div class="note" role="doc-note">

--- a/pizero-book/docs/javascript.html
+++ b/pizero-book/docs/javascript.html
@@ -20,7 +20,7 @@
         <h2 id="javascript-の基礎">JavaScript の基礎</h2>
         <p>JavaScript に慣れていない人は、下記ページを参考にしてください。</p>
         <ul>
-          <li>「JavaScript 初学者向け資料集」<span class="footnote">13 章の参考リンクから該当情報を参照ください</span>を参照してください。</li>
+          <li>「JavaScript 初学者向け資料集」（13 章 予備知識参照）を参照してください。</li>
         </ul>
       </section>
       <section class="level2" aria-labelledby="javascriptコードライブラリの読み込み">

--- a/pizero-book/docs/javascript.md
+++ b/pizero-book/docs/javascript.md
@@ -6,7 +6,7 @@
 ## JavaScript の基礎
 JavaScript に慣れていない人は、下記ページを参考にしてください。
 
-* 「JavaScript 初学者向け資料集」<span class="footnote">13 章の参考リンクから該当情報を参照ください</span>を参照してください。
+* 「JavaScript 初学者向け資料集」（13 章 予備知識参照）を参照してください。
 
 ## JavaScriptコード・ライブラリの読み込み
 

--- a/pizero-book/docs/try-gpio.html
+++ b/pizero-book/docs/try-gpio.html
@@ -28,7 +28,7 @@
       </section>
       <section class="level2" aria-labelledby="gpio出力">
         <h2 id="gpio出力">GPIO出力</h2>
-        <p>GPIOの出力はLチカで実験済みですね。そこで今回はモーターを動かしてみましょう。MOSFET<span class="footnote">13 章の参考リンクから該当情報を参照ください</span>を使った回路図は以下のようになります。</p>
+        <p>GPIOの出力はLチカで実験済みですね。そこで今回はモーターを動かしてみましょう。MOSFET（13 章 予備知識参照）を使った回路図は以下のようになります。</p>
         <figure>
           <img src="../../pizero/esm-examples/hello-real-world/PiZero_gpio0Motor.png" alt="GPIO Motor" height="190">
           <figcaption aria-hidden="true">GPIO Motor</figcaption>

--- a/pizero-book/docs/try-gpio.md
+++ b/pizero-book/docs/try-gpio.md
@@ -23,7 +23,7 @@ GPIOポートを入力モードで使用する場合、ポートが解放状態(
 
 ## GPIO出力
 
-GPIOの出力はLチカで実験済みですね。そこで今回はモーターを動かしてみましょう。MOSFET<span class="footnote">13 章の参考リンクから該当情報を参照ください</span>を使った回路図は以下のようになります。
+GPIOの出力はLチカで実験済みですね。そこで今回はモーターを動かしてみましょう。MOSFET（13 章 予備知識参照）を使った回路図は以下のようになります。
 
 ![GPIO Motor](../../pizero/esm-examples/hello-real-world/PiZero_gpio0Motor.png){height=190}
 


### PR DESCRIPTION
予備知識への脚注を`（13 章 予備知識参照）`に変更
<img width="522" alt="スクリーンショット 2023-10-28 15 40 35" src="https://github.com/gurezo/chirimen.org/assets/7631567/5c0508bc-6218-433a-844f-f8881c73e41e">
<img width="570" alt="スクリーンショット 2023-10-28 15 43 21" src="https://github.com/gurezo/chirimen.org/assets/7631567/944c65f4-9ee2-4bd0-90f4-36d314e835b4">
<img width="547" alt="スクリーンショット 2023-10-28 15 41 26" src="https://github.com/gurezo/chirimen.org/assets/7631567/0f7c9f01-0666-4e34-b4a0-2a291a70d27a">
